### PR TITLE
update statistics.skirmishChests for EoD

### DIFF
--- a/src/statistics/items.js
+++ b/src/statistics/items.js
@@ -132,7 +132,7 @@ export default function (accountData) {
 
     // (12) WORLD VS WORLD
     potionOfWvwRewards: countItems(items, 78600),
-    skirmishChests: countItems(items, [84966, 81324]),
+    skirmishChests: countItems(items, [84966, 81324, 96536]),
 
     // (13) PLAYER VS PLAYER
     potionOfPvpRewards: countItems(items, 68110),


### PR DESCRIPTION
with EoD the dropped chests changed again as the new chests allow to buy "Testimony of Jade Heroics" instead of "Testimony of Desert Heroics"