### PR TITLE
Remove unbound endless inner demon combat tonic

### DIFF
--- a/src/statistics/items.js
+++ b/src/statistics/items.js
@@ -362,7 +362,6 @@ function unstableFractalEssenceFromItems (items) {
     81790: 450, // Celestial Infusion Chest
     ...idListToWeightMap(cosmeticAuraItemMap.celestialInfusionRed, 450), // Celestial Infusion (Red)
     81632: 450, // Endless Chaos Combat Tonic
-    94021: 1680, // Endless Inner Demon Combat Tonic
     94055: 1680, // Endless Inner Demon Combat Tonic
     81743: 5 // Unstable Cosmic Essence
   }

--- a/tests/items.spec.js
+++ b/tests/items.spec.js
@@ -899,7 +899,7 @@ describe('statistics > items', () => {
       {id: 81790, count: 1}, // Celestial Infusion Chest
       {id: 82070, count: 1}, // Celestial Infusion (Red)
       {id: 81632, count: 1}, // Endless Chaos Combat Tonic
-      {id: 94021, count: 1}, // Endless Inner Demon Combat Tonic
+      {id: 94055, count: 1}, // Endless Inner Demon Combat Tonic
 
       {id: 81761, count: 9999999} // Celestial Infusion (Blue) -- (!) Does not count
     ]))._unstableFractalEssenceFromItems).to.equal(7410)


### PR DESCRIPTION
Removed the unbound version of the endless inner demon combat tonic from the unstableFractalEssenceFromItems function's map to let only the bound version.
Also edited the test for it to check for the bound version instead.