### PR TITLE
Add mad kings clock tower completions

### DIFF
--- a/src/statistics/progression.js
+++ b/src/statistics/progression.js
@@ -10,6 +10,7 @@ export default function (accountData) {
     southsunSurvivalRounds: achievementCurrent(accountData, 752, 6),
     crabTossRounds: achievementCurrent(accountData, 757, 12),
     winterWonderlandCompletions: winterWonderlandCompletions(accountData),
+    madKingsClockTowerCompletions: achievementCurrent(accountData, 3926, 3),
     wvwPlayerKills: achievementCurrent(accountData, 283),
     wvwSupplyCaravansKilled: achievementCurrent(accountData, 288),
     wvwSupplyCaravansEscorted: achievementCurrent(accountData, 285),

--- a/tests/progression.spec.js
+++ b/tests/progression.spec.js
@@ -106,6 +106,14 @@ describe('statistics > progression', () => {
     }).winterWonderlandCompletions).to.equal(8293)
   })
 
+  it('can calculate the completed mad king\'s clock tower jps', () => {
+    expect(progressionStatistics({}).madKingsClockTowerCompletions).to.equal(null)
+    expect(progressionStatistics({achievements: []}).madKingsClockTowerCompletions).to.equal(0)
+    expect(progressionStatistics({
+      achievements: [{id: 3926, current: 1, max: 3, done: true, repeated: 15}]
+    }).madKingsClockTowerCompletions).to.equal(46)
+  })
+
   it('can calculate the completed dungeons', () => {
     expect(progressionStatistics({}).completedDungeons).to.equal(null)
     expect(progressionStatistics({achievements: []}).completedDungeons).to.equal(0)


### PR DESCRIPTION
Similar to the existing winter wonderland completions statistic, I thought it would be nice to have a mad king's clock tower completions counter on the site. 

I tried finding all achievements that track or tracked clock tower completions:
- 2012: only the first completion was tracked by "Mad King's Clock Tower" (id 365), which is not in the API. [1][2]
- 2013 to 2016: no achievements for tower completions. [3][4][5][6]
- 2017+: "Clocktower's Champion" (id 3926), which we use. [7] 

There is also "Mad King's Clock Tower" (id 3915), but this was introduced in 2017 so I heavily suspect the completion here is counted by "Clocktower's Champion" already. [8]

There is also "Court Duty: Terror of the Tower" (id 6039), which is a sort of proxy for completions but it was introduced in 2021, so all completions counted by this are counted by "Clocktower's Champion" already. [9]

So in conclusion, similar to how we can't accurately count winter wonderland completions from 2012, we also can't count any clock tower completions before 2017. Still think its worth having though.

[1] https://wiki.guildwars2.com/wiki/Shadow_of_the_Mad_King_(2012_achievements)#achievement365
[2] https://api.guildwars2.com/v2/achievements?ids=365
[3] https://wiki.guildwars2.com/wiki/Blood_and_Madness_(2013_achievements)
[4] https://wiki.guildwars2.com/wiki/Blood_and_Madness_(2014_achievements)
[5] https://wiki.guildwars2.com/wiki/Shadow_of_the_Mad_King_(2015_achievements)
[6] https://wiki.guildwars2.com/wiki/Shadow_of_the_Mad_King_(2016_achievements)
[7] https://wiki.guildwars2.com/wiki/Halloween_Rituals#achievement3926
[8] https://wiki.guildwars2.com/wiki/Lunatic_Wardrobe#achievement3915
[9] https://wiki.guildwars2.com/wiki/Shadow_of_the_Mad_King_(achievements)#achievement6039